### PR TITLE
Fix Atomic generator bug where pre-commit files were ignored if the post-commit file exists

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 {{$NEXT}}
 
+- The fix for Atomic file generator steps in the last release introduced a new
+  bug. If the pre-commit and post-commit files both existed, the pre-commit
+  file would just be ignored. We want to use the pre-commit file whenever one
+  is generated.
+
+
 0.003002 2015-02-23
 
 [BACKWARDS INCOMPATIBILITIES]

--- a/lib/Stepford/Role/Step/FileGenerator/Atomic.pm
+++ b/lib/Stepford/Role/Step/FileGenerator/Atomic.pm
@@ -59,7 +59,7 @@ around run => sub {
 
     # The step's run() method may decide to simply not do anything if the
     # post-commit file already exists, and that's ok.
-    return if -f $post_commit;
+    return if -f $post_commit && ! -f $pre_commit;
 
     croak 'The '
         . ( ref $self )
@@ -68,6 +68,7 @@ around run => sub {
         . " $pre_commit"
         unless -f $pre_commit;
 
+    $self->logger()->debug("Renaming $pre_commit to $post_commit");
     rename( $pre_commit, $post_commit )
         or croak "Failed renaming $pre_commit -> $post_commit: $!";
 };


### PR DESCRIPTION
If the step chooses to generate the pre-commit file we should always use
that. If it _doesn't_ generate the file then we want to use the post-commit
file if it exists and throw an error otherwise.

Also added some debug logging to indicate that the pre-commit file is being
renamed to the post-commit name.